### PR TITLE
Fix future incompatibility report

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ keywords = ["file", "dialog", "ui"]
 build = "build.rs"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0.79"
 

--- a/build.rs
+++ b/build.rs
@@ -20,18 +20,18 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-extern crate gcc;
+extern crate cc;
 use std::env;
 use std::process::Command;
 
 macro_rules! nfd {
     ($suf:expr) => {
-        concat!("nativefiledialog/src/", $suf);
+        concat!("nativefiledialog/src/", $suf)
     };
 }
 
 fn main() {
-    let mut cfg = gcc::Config::new();
+    let mut cfg = cc::Build::new();
     let env = env::var("TARGET").unwrap();
 
     cfg.include(nfd!("include"));

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,15 +20,7 @@ impl fmt::Display for NFDError {
     }
 }
 
-impl Error for NFDError {
-    fn description(&self) -> &str {
-        match *self {
-            NFDError::NulError(ref err) => err.description(),
-            NFDError::Error(ref err) => err,
-            NFDError::Utf8Error(ref err) => err.description(),
-        }
-    }
-}
+impl Error for NFDError {}
 
 impl From<ffi::NulError> for NFDError {
     fn from(err: ffi::NulError) -> NFDError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub fn open_dialog(filter_list: Option<&str>, default_path: Option<&str>, dialog
 
     let filter_list_ptr = match filter_list {
         Some(fl_str) => {
-            filter_list_cstring = try!(CString::new(fl_str));
+            filter_list_cstring = CString::new(fl_str)?;
             filter_list_cstring.as_ptr()
         }
         None => std::ptr::null()
@@ -126,7 +126,7 @@ pub fn open_dialog(filter_list: Option<&str>, default_path: Option<&str>, dialog
 
     let default_path_ptr = match default_path {
         Some(dp_str) => {
-            default_path_cstring = try!(CString::new(dp_str));
+            default_path_cstring = CString::new(dp_str)?;
             default_path_cstring.as_ptr()
         }
         None => std::ptr::null()


### PR DESCRIPTION
> The following warnings were discovered during the build. These warnings are an indication that the packages contain code that will become an error in a future release of Rust. These warnings typically cover changes to close soundness problems, unintended or undocumented behavior, or critical problems that cannot be fixed in a backwards-compatible fashion, and are not expected to be in wide use.
> Each warning should contain a link for more information on what the warning means and how to resolve it.
> To solve this problem, you can try the following approaches:
> - If the issue is not solved by updating the dependencies, a fix has to be implemented by those dependencies. You can help with that by notifying the maintainers of this problem (e.g. by creating a bug report) or by proposing a fix to the maintainers (e.g. by creating a pull request):
>   - nfd@0.0.4
>   - Repository: https://www.github.com/saurvs/nfd-rs
>   - Detailed warning command: `cargo report future-incompatibilities --id 226 --package nfd@0.0.4`
> - If waiting for an upstream fix is not an option, you can use the `[patch]` section in `Cargo.toml` to use your own version of the dependency. For more information, see:
> https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
> 
> The package `nfd v0.0.4 (https://github.com/raphlinus/nfd-rs?rev=5e09b79bf511e3a91ae8cefdb96e9734fa4a79c2#5e09b79b)` currently triggers the following future incompatibility lints:
> > warning: trailing semicolon in macro used in expression position
> >   --> /home/fred/.cargo/git/checkouts/nfd-rs-c8063fc3bb0fe80d/5e09b79/build.rs:29:47
> >    |
> > 29 |         concat!("nativefiledialog/src/", $suf);
> >    |                                               ^
> > ...
> > 37 |     cfg.include(nfd!("include"));
> >    |                 --------------- in this macro invocation
> >    |
> >    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
> >    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
> >    = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
> >    = note: this warning originates in the macro `nfd` (in Nightly builds, run with -Z macro-backtrace for more info)
> >
> > warning: trailing semicolon in macro used in expression position
> >   --> /home/fred/.cargo/git/checkouts/nfd-rs-c8063fc3bb0fe80d/5e09b79/build.rs:29:47
> >    |
> > 29 |         concat!("nativefiledialog/src/", $suf);
> >    |                                               ^
> > ...
> > 38 |     cfg.file(nfd!("nfd_common.c"));
> >    |              -------------------- in this macro invocation
> >    |
> >    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
> >    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
> >    = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
> >    = note: this warning originates in the macro `nfd` (in Nightly builds, run with -Z macro-backtrace for more info)
> >
> > warning: trailing semicolon in macro used in expression position
> >   --> /home/fred/.cargo/git/checkouts/nfd-rs-c8063fc3bb0fe80d/5e09b79/build.rs:29:47
> >    |
> > 29 |         concat!("nativefiledialog/src/", $suf);
> >    |                                               ^
> > ...
> > 41 |         cfg.file(nfd!("nfd_cocoa.m"));
> >    |                  ------------------- in this macro invocation
> >    |
> >    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
> >    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
> >    = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
> >    = note: this warning originates in the macro `nfd` (in Nightly builds, run with -Z macro-backtrace for more info)
> >
> > warning: trailing semicolon in macro used in expression position
> >   --> /home/fred/.cargo/git/checkouts/nfd-rs-c8063fc3bb0fe80d/5e09b79/build.rs:29:47
> >    |
> > 29 |         concat!("nativefiledialog/src/", $suf);
> >    |                                               ^
> > ...
> > 46 |         cfg.file(nfd!("nfd_win.cpp"));
> >    |                  ------------------- in this macro invocation
> >    |
> >    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
> >    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
> >    = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
> >    = note: this warning originates in the macro `nfd` (in Nightly builds, run with -Z macro-backtrace for more info)
> >
> > warning: trailing semicolon in macro used in expression position
> >   --> /home/fred/.cargo/git/checkouts/nfd-rs-c8063fc3bb0fe80d/5e09b79/build.rs:29:47
> >    |
> > 29 |         concat!("nativefiledialog/src/", $suf);
> >    |                                               ^
> > ...
> > 72 |         cfg.file(nfd!("nfd_gtk.c"));
> >    |                  ----------------- in this macro invocation
> >    |
> >    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
> >    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
> >    = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
> >    = note: this warning originates in the macro `nfd` (in Nightly builds, run with -Z macro-backtrace for more info)
> >